### PR TITLE
feat: stop yaml truncating trailing 0 in float

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: "1.20"
 
     - name: Build
       run: go build -v ./...

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
```
./domain_exporter --config="domains.yaml"
ts=2023-08-17T11:58:49.816Z caller=main.go:82 level=info msg="Starting domain_exporter" version="(version=, branch=, revision=3c440d2ef68e3edd4ae164afbae70bbb1e55d87b)"
ts=2023-08-17T11:58:49.816Z caller=main.go:83 level=info msg="Build context" (gogo1.21.0,platformdarwin/arm64,user,date,tagsunknown)=(MISSING)
ts=2023-08-17T11:58:49.816Z caller=main.go:123 level=info msg=Listening port=:9203
ts=2023-08-17T11:58:49.876Z caller=main.go:176 level=info domain:=google.com date=2028-09-14T04:00:00Z
ts=2023-08-17T11:58:49.934Z caller=main.go:110 level=warn warn="Unable to parse date: Last updated:  10-Dec-2020, for bbc.co.uk\n"
ts=2023-08-17T11:58:49.967Z caller=main.go:176 level=info domain:=ycombinator.com date=2024-03-20T22:51:07Z
^C
```